### PR TITLE
Update pyfuzz2_server.py

### DIFF
--- a/pyfuzz2_server.py
+++ b/pyfuzz2_server.py
@@ -13,7 +13,6 @@ from worker.beaconworker import BeaconWorker
 from worker.reportworker import ReportWorker
 from worker.nodeclientworker import NodeClientWorker
 from worker.webworker import WebWorker
-from web.main import WebSite
 from model.database import DB_TYPES
 from model.config import ConfigParser
 from node.model.message_types import MESSAGE_TYPES


### PR DESCRIPTION
This import  "from web.main import WebSite" is never used and generate this error 
I:\PyFuzz2\PyFuzz2-master>python pyfuzz2_server.py
Traceback (most recent call last):
  File "pyfuzz2_server.py", line 16, in <module>
    from web.main import WebSite
  File "C:\Python27\lib\site-packages\gevent\builtins.py", line 93, in **import**
    result = _import(_args, *_kwargs)
ImportError: No module named main
